### PR TITLE
handle options.external being a function

### DIFF
--- a/src/plugin.mjs
+++ b/src/plugin.mjs
@@ -16,7 +16,13 @@ export default function esmImportToUrl({
 
                 if (notBare(key)) return;
 
-                if (options.external.includes(key)) throw Error('Import specifier must NOT be present in the Rollup external config. Please remove specifier from the Rollup external config.');
+                if (typeof options.external === 'function') {
+                    if (options.external(key)) throw Error('Import specifier must NOT be present in the Rollup external config. Please remove specifier from the Rollup external config.');
+                }
+                if (Array.isArray(options.external)) {
+                    if (options.external.includes(key)) throw Error('Import specifier must NOT be present in the Rollup external config. Please remove specifier from the Rollup external config.');
+                }
+
                 if (notUrl(value)) throw Error('Target for import specifier must be an absolute URL.');
 
                 mapping.set(key, value);


### PR DESCRIPTION
https://rollupjs.org/guide/en/#external

> Either a function that takes an id and returns true (external) or false (not external), or an Array of module IDs, or regular expressions to match module IDs, that should remain external to the bundle. Can also be just a single ID or regular expression.

options.external can be an array or a function. 

This PR checks and handles both cases